### PR TITLE
Add api to skip events in development environments

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,19 +35,3 @@ jobs:
 
       - name: Run tests
         run: npm test run --typecheck
-
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["javascript", "TypeScript"]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ const plausible = new Plausible({
 });
 ```
 
+Transformation hook is runs after filter.
+
 # Development
 
 `plausible-client` is an truth open source project, so you are welcome on [project github repository](https://github.com/vitonsky/plausible-client/) to contribute a code, [make issues](https://github.com/vitonsky/plausible-client/issues/new/choose) with feature requests and bug reports.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ You may filter out specific events.
 
 It may be useful to skip events of users who should not be tracked, ignore irrelevant events by its props, and for development purposes.
 
-Just define predicate `filter` in config, that receive event object and return `true` to send request and `false` to skip.
+Just define predicate `filter` in config:
+- it receive event object as first parameter and event name as second
+- it must return `true` to send request and `false` to skip
 
 ```ts
 import { Plausible, enableAutoOutboundTracking } from 'plausible-client';
@@ -82,7 +84,7 @@ import { Plausible, enableAutoOutboundTracking } from 'plausible-client';
 const plausible = new Plausible({
   apiHost: 'https://plausible.io',
   domain: 'example.org',
-  filter(event) {
+  filter(event, eventName) {
     // Skip all events while development
     if (location.hostname === 'localhost') {
       console.warn('Analytics event is skipped, since run on localhost', event);
@@ -94,6 +96,9 @@ const plausible = new Plausible({
 
     // Skip events by event props
     if (event.props.group === 'no-track') return false;
+
+    // Skip events by its name, for users who does not participate in preview program
+    if (!event.props.previewEnabled && eventName.startsWith('preview:')) return false;
 
     // Pass all events otherwise
     return true;
@@ -107,7 +112,9 @@ You may transform events.
 
 It may be useful to enrich events data or redact some collected data.
 
-Just define option `transform` in config, that receive event object and return new event object.
+Just define option `transform` in config
+- it receive event object and event name
+- it must return new event object.
 
 ```ts
 import { Plausible, enableAutoOutboundTracking } from 'plausible-client';
@@ -115,7 +122,7 @@ import { Plausible, enableAutoOutboundTracking } from 'plausible-client';
 const plausible = new Plausible({
   apiHost: 'https://plausible.io',
   domain: 'example.org',
-  transform(event) {
+  transform(event, eventName) {
     event.props = {
       ...event.props,
       group: 'clients',

--- a/README.md
+++ b/README.md
@@ -68,6 +68,39 @@ const plausible = new Plausible({
 enableAutoOutboundTracking(plausible);
 ```
 
+## Filter events
+
+You may filter out specific events.
+
+It may be useful to skip events of users who should not be tracked, ignore irrelevant events by its props, and for development purposes.
+
+Just define predicate `filter` in config, that receive event object and return `true` to send request and `false` to skip.
+
+```ts
+import { Plausible, enableAutoOutboundTracking } from 'plausible-client';
+
+const plausible = new Plausible({
+  apiHost: 'https://plausible.io',
+  domain: 'example.org',
+  filter(event) {
+    // Skip all events while development
+    if (location.hostname === 'localhost') {
+      console.warn('Analytics event is skipped, since run on localhost', event);
+      return false;
+    }
+
+    // Skip all events for users who don't want to be tracked
+    if (window.localStorage.plausible_ignore === 'true') return false;
+
+    // Skip events by event props
+    if (event.props.group === 'no-track') return false;
+
+    // Pass all events otherwise
+    return true;
+  }
+});
+```
+
 # Development
 
 `plausible-client` is an truth open source project, so you are welcome on [project github repository](https://github.com/vitonsky/plausible-client/) to contribute a code, [make issues](https://github.com/vitonsky/plausible-client/issues/new/choose) with feature requests and bug reports.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,33 @@ const plausible = new Plausible({
 });
 ```
 
+## Transform events
+
+You may transform events.
+
+It may be useful to enrich events data or redact some collected data.
+
+Just define option `transform` in config, that receive event object and return new event object.
+
+```ts
+import { Plausible, enableAutoOutboundTracking } from 'plausible-client';
+
+const plausible = new Plausible({
+  apiHost: 'https://plausible.io',
+  domain: 'example.org',
+  transform(event) {
+    event.props = {
+      ...event.props,
+      group: 'clients',
+      userId: event.props.uid ? "uuid:" + event.props.uid : undefined,
+      isPreferDarkTheme: window.matchMedia("(prefers-color-scheme: dark)").matches,
+    };
+
+    return event;
+  }
+});
+```
+
 # Development
 
 `plausible-client` is an truth open source project, so you are welcome on [project github repository](https://github.com/vitonsky/plausible-client/) to contribute a code, [make issues](https://github.com/vitonsky/plausible-client/issues/new/choose) with feature requests and bug reports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "plausible-client",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "plausible-client",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@commitlint/cli": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "plausible-client",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"type": "module",
 	"description": "Plausible analytics client with no hassle",
 	"keywords": ["plausible", "analytics"],

--- a/src/Plausible.test.ts
+++ b/src/Plausible.test.ts
@@ -47,6 +47,11 @@ test('should call fetch with correct params', async () => {
 					r: null,
 					w: 1024,
 					h: 0,
+					p: JSON.stringify({
+						foo: 1,
+						bar: 'string',
+						baz: null,
+					}),
 				}),
 				keepalive: true,
 			},

--- a/src/Plausible.test.ts
+++ b/src/Plausible.test.ts
@@ -1,4 +1,4 @@
-import { Plausible } from './Plausible';
+import { EventProps, Plausible } from './Plausible';
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -135,4 +135,82 @@ test('events filter', async () => {
 		],
 	]);
 	expect(mockFetch.mock.calls).toEqual([]);
+});
+
+test('events transforming', async () => {
+	mockFetch.mockReturnValue(new Response('ok'));
+
+	const transform = vi.fn();
+
+	const plausible = new Plausible({
+		apiHost: 'https://plausible.io',
+		domain: 'example.org',
+		transform,
+	});
+
+	// Event will be transformed
+	vi.clearAllMocks();
+	transform.mockImplementation((event: EventProps) => {
+		// Clone object, to avoid mutation,
+		// that makes test code is difficult to understand
+		const newEvent = structuredClone(event);
+
+		newEvent.props = {
+			...newEvent.props,
+			bar: 2,
+			baz: 3,
+		};
+
+		return newEvent;
+	});
+
+	await expect(
+		plausible.sendEvent('test', {
+			props: {
+				foo: 1,
+				bar: 1,
+			},
+		}),
+	).resolves.toBeUndefined();
+
+	// Received original event object
+	expect(transform.mock.calls).toEqual([
+		[
+			{
+				deviceWidth: 1024,
+				hashMode: false,
+				referrer: null,
+				url: 'https://example.org/',
+				props: {
+					foo: 1,
+					bar: 1,
+				},
+			},
+		],
+	]);
+
+	// Sent modified event object
+	expect(mockFetch.mock.calls).toEqual([
+		[
+			'https://plausible.io/api/event',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'text/plain' },
+				body: JSON.stringify({
+					n: 'test',
+					u: 'https://example.org/',
+					d: 'example.org',
+					r: null,
+					w: 1024,
+					h: 0,
+					p: JSON.stringify({
+						foo: 1,
+						bar: 2,
+						baz: 3,
+					}),
+				}),
+				keepalive: true,
+			},
+		],
+	]);
 });

--- a/src/Plausible.test.ts
+++ b/src/Plausible.test.ts
@@ -58,3 +58,81 @@ test('should call fetch with correct params', async () => {
 		],
 	]);
 });
+
+test('events filter', async () => {
+	mockFetch.mockReturnValue(new Response('ok'));
+
+	const filter = vi.fn();
+
+	const plausible = new Plausible({
+		apiHost: 'https://plausible.io',
+		domain: 'example.org',
+		filter,
+	});
+
+	// Event will not be sent
+	vi.clearAllMocks();
+	filter.mockReturnValue(false);
+	await expect(plausible.sendEvent('test')).resolves.toBeUndefined();
+	expect(filter.mock.calls).toEqual([
+		[
+			{
+				deviceWidth: 1024,
+				hashMode: false,
+				referrer: null,
+				url: 'https://example.org/',
+			},
+		],
+	]);
+	expect(mockFetch.mock.calls).toEqual([]);
+
+	// Event will be sent
+	vi.clearAllMocks();
+	filter.mockReturnValue(true);
+	await expect(plausible.sendEvent('test')).resolves.toBeUndefined();
+	expect(filter.mock.calls).toEqual([
+		[
+			{
+				deviceWidth: 1024,
+				hashMode: false,
+				referrer: null,
+				url: 'https://example.org/',
+			},
+		],
+	]);
+	expect(mockFetch.mock.calls).toEqual([
+		[
+			'https://plausible.io/api/event',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'text/plain' },
+				body: JSON.stringify({
+					n: 'test',
+					u: 'https://example.org/',
+					d: 'example.org',
+					r: null,
+					w: 1024,
+					h: 0,
+					p: undefined,
+				}),
+				keepalive: true,
+			},
+		],
+	]);
+
+	// Event will not be sent
+	vi.clearAllMocks();
+	filter.mockReturnValue(false);
+	await expect(plausible.sendEvent('test')).resolves.toBeUndefined();
+	expect(filter.mock.calls).toEqual([
+		[
+			{
+				deviceWidth: 1024,
+				hashMode: false,
+				referrer: null,
+				url: 'https://example.org/',
+			},
+		],
+	]);
+	expect(mockFetch.mock.calls).toEqual([]);
+});

--- a/src/Plausible.test.ts
+++ b/src/Plausible.test.ts
@@ -82,6 +82,7 @@ test('events filter', async () => {
 				referrer: null,
 				url: 'https://example.org/',
 			},
+			'test',
 		],
 	]);
 	expect(mockFetch.mock.calls).toEqual([]);
@@ -98,6 +99,7 @@ test('events filter', async () => {
 				referrer: null,
 				url: 'https://example.org/',
 			},
+			'test',
 		],
 	]);
 	expect(mockFetch.mock.calls).toEqual([
@@ -132,6 +134,7 @@ test('events filter', async () => {
 				referrer: null,
 				url: 'https://example.org/',
 			},
+			'test',
 		],
 	]);
 	expect(mockFetch.mock.calls).toEqual([]);
@@ -186,6 +189,7 @@ test('events transforming', async () => {
 					bar: 1,
 				},
 			},
+			'test',
 		],
 	]);
 

--- a/src/Plausible.ts
+++ b/src/Plausible.ts
@@ -26,6 +26,13 @@ export type PlausibleInitOptions = {
 	 * Defaults to `'https://plausible.io'`
 	 */
 	readonly apiHost: string;
+
+	/**
+	 * Predicate that receive event and decide should event be sent or be skipped
+	 * @param event current event
+	 * @returns `boolean`, if `false` - request will be skipped
+	 */
+	readonly filter?: (event: EventProps) => boolean;
 };
 
 type EventProps = {
@@ -54,7 +61,10 @@ export class Plausible {
 	}
 
 	private sendRequest = async (eventName: string, data: EventProps) => {
-		const { apiHost, domain } = this.config;
+		const { apiHost, domain, filter } = this.config;
+
+		// Skip event
+		if (filter && !filter(data)) return;
 
 		const payload: EventPayload = {
 			n: eventName,

--- a/src/Plausible.ts
+++ b/src/Plausible.ts
@@ -32,14 +32,14 @@ export type PlausibleInitOptions = {
 	 * @param event current event object
 	 * @returns `boolean`, if `false` - request will be skipped
 	 */
-	readonly filter?: (event: EventProps) => boolean;
+	readonly filter?: (event: EventProps, eventName: string) => boolean;
 
 	/**
 	 * Event object transformer
 	 * @param event current event object
 	 * @returns new event object
 	 */
-	readonly transform?: (event: EventProps) => EventProps;
+	readonly transform?: (event: EventProps, eventName: string) => EventProps;
 };
 
 export type EventProps = {
@@ -71,11 +71,11 @@ export class Plausible {
 		const { apiHost, domain, filter, transform } = this.config;
 
 		// Skip event
-		if (filter && !filter(data)) return;
+		if (filter && !filter(data, eventName)) return;
 
 		// Transform data
 		if (transform) {
-			data = transform(data);
+			data = transform(data, eventName);
 		}
 
 		const payload: EventPayload = {

--- a/src/Plausible.ts
+++ b/src/Plausible.ts
@@ -29,13 +29,20 @@ export type PlausibleInitOptions = {
 
 	/**
 	 * Predicate that receive event and decide should event be sent or be skipped
-	 * @param event current event
+	 * @param event current event object
 	 * @returns `boolean`, if `false` - request will be skipped
 	 */
 	readonly filter?: (event: EventProps) => boolean;
+
+	/**
+	 * Event object transformer
+	 * @param event current event object
+	 * @returns new event object
+	 */
+	readonly transform?: (event: EventProps) => EventProps;
 };
 
-type EventProps = {
+export type EventProps = {
 	url: string;
 	referrer: string | null;
 	deviceWidth: number;
@@ -61,10 +68,15 @@ export class Plausible {
 	}
 
 	private sendRequest = async (eventName: string, data: EventProps) => {
-		const { apiHost, domain, filter } = this.config;
+		const { apiHost, domain, filter, transform } = this.config;
 
 		// Skip event
 		if (filter && !filter(data)) return;
+
+		// Transform data
+		if (transform) {
+			data = transform(data);
+		}
 
 		const payload: EventPayload = {
 			n: eventName,


### PR DESCRIPTION
Closes #6

Key changes
- Implemented option `filter`, to skip events
- Implemented option `transform`, to transform event objects
- Fixed CI to run tests
- Updated minor package version, since has been added significant changes with new features